### PR TITLE
Fix: "ambiguating new declaration of ‘uint64_t _xgetbv(uint32_t)’"

### DIFF
--- a/SourceFiles/UtilityFunctions.cpp
+++ b/SourceFiles/UtilityFunctions.cpp
@@ -125,7 +125,7 @@ void run_cpuid(uint32_t eax, uint32_t ecx, int32_t *abcd)
 	abcd[3] = d;
 }
 
-static uint64_t _xgetbv(uint32_t xcr)
+static uint64_t __xgetbv(uint32_t xcr)
 {
 	uint32_t eax, edx;
 
@@ -138,7 +138,7 @@ static uint64_t _xgetbv(uint32_t xcr)
 int32_t check_xcr0_ymm()
 {
 	uint32_t xcr0;
-	xcr0 = (uint32_t)_xgetbv(0);
+	xcr0 = (uint32_t)__xgetbv(0);
 	return ((xcr0 & 6) == 6); /* checking if xmm and ymm state are enabled in XCR0 */
 }
 


### PR DESCRIPTION
This fixes a build error that seems to be a recent problem with GCC 8. I've renamed `_xgetbv` -> `__xgetbv` to avoid a name collision with GCC's internal header.


## Error log

```
[  7%] Building CXX object CMakeFiles/MerikensTripcodeEngine.dir/Main.cpp.o
[ 14%] Building CXX object CMakeFiles/MerikensTripcodeEngine.dir/Patterns.cpp.o
[ 21%] Building CXX object CMakeFiles/MerikensTripcodeEngine.dir/Verification10.cpp.o
[ 28%] Building CXX object CMakeFiles/MerikensTripcodeEngine.dir/Testing.cpp.o
[ 35%] Building CXX object CMakeFiles/MerikensTripcodeEngine.dir/Verification12.cpp.o
[ 42%] Building CXX object CMakeFiles/MerikensTripcodeEngine.dir/VerificationDuplicates.cpp.o
[ 50%] Building CXX object CMakeFiles/MerikensTripcodeEngine.dir/UtilityFunctions.cpp.o
[ 57%] Building CXX object CMakeFiles/MerikensTripcodeEngine.dir/CPU10_AVX2Intrinsics.cpp.o
/home/takumi/dev/merikens-tripcode-engine-v3/SourceFiles/UtilityFunctions.cpp:128:17: error: ambiguating new declaration of ‘uint64_t _xgetbv(uint32_t)’
 static uint64_t _xgetbv(uint32_t xcr)
                 ^~~~~~~
In file included from /usr/lib/gcc/x86_64-linux-gnu/8/include/x86intrin.h:74,
                 from /home/takumi/dev/merikens-tripcode-engine-v3/SourceFiles/MerikensTripcodeEngine.h:117,
                 from /home/takumi/dev/merikens-tripcode-engine-v3/SourceFiles/UtilityFunctions.cpp:1:
/usr/lib/gcc/x86_64-linux-gnu/8/include/xsaveintrin.h:60:1: note: old declaration ‘long long int _xgetbv(unsigned int)’
 _xgetbv (unsigned int __A)
 ^~~~~~~
make[2]: *** [CMakeFiles/MerikensTripcodeEngine.dir/build.make:141: CMakeFiles/MerikensTripcodeEngine.dir/UtilityFunctions.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:104: CMakeFiles/MerikensTripcodeEngine.dir/all] Error 2
make: *** [Makefile:130: all] Error 2
```